### PR TITLE
Add readme; update scalability script for Chapel implementations

### DIFF
--- a/chplPingPong/README
+++ b/chplPingPong/README
@@ -1,0 +1,45 @@
+This directory contains two Chapel-based implementations of the "Ping Pong"
+benchmark written using two "alternative" algorithms from DES.  These are:
+
+- pingPongBallFocused.chpl -- which works by not allocating any storage for
+  the grid of pongers and instead stores the (x,y) locations of balls in a
+  distributed array.  
+- pingPongStencil.chpl -- which works by storing four block distributed arrays
+  indicating at each "ponger" location how many balls are headed north, south,
+  west, and east.
+
+The "ball focused" version can be passed an 'algorithm' configuration constant
+to specify whether we should have the timestep loop as a synchronizing outer
+loop or an asynchronous inner loop. Having it as an inner loop leads to better
+parallel scalability (as no synchronization is necessary between time steps)
+but may be less realistic since this is only possible because none of the
+"balls" interact with one another.  We would expect the performance of this
+version to be independent of the size of the grid but impacted by the number of
+balls in flight.
+
+The "stencil" version has a synchronizing outer time loop and can update all
+four distributed arrays in parallel.  We would expect the performance of this
+version to be independent of the number of balls in flight but impacted by the
+size of the grid.
+
+Both Chapel versions require significantly less memory than the SST-based
+version and perform much faster; however, the Chapel versions are specifically
+written for this "ping pong" example and SST is a more general framework.  The
+"ping pong" application has a number of characteristics that make it suitable
+for the algorithms studied in this directory If these characteristics and
+assumptions were changed than it may be less suitable.
+
+Some simplifying characteristics include that:
+
+- all edges in its component graph have the same weight.
+- all interactions are independent (for example, I don't have "balls" bounce
+  off of each other).
+- connectivity among components is completely regular (e.g. the components form
+  a perfect 2D grid).
+- the amount of "work" to update a component is minimal (we simply pass a
+  message along from one component to another).
+- all the components are the same and perform the exact same logic.
+
+To run experiments using these versions modify and execute the 'doit' script in
+this directory.  The script has various parameters at the top that can be
+modified to direct the script what to conduct.

--- a/chplPingPong/doit
+++ b/chplPingPong/doit
@@ -39,7 +39,7 @@ if [[ "$runStrongScaling" == 'true' ]]; then
       for nc in "${nodecount[@]}"; do
         for pn_msg in "${num_balls[@]}"; do
           for pn_els in "${sqrt_els[@]}"; do
-            (set -x ./pingPongBallFocused -nl $nc --N=$pn_els --numDims=2 --numBalls=$pn_msg --timeToRun=$time_to_run --algorithm=$alg)
+            (set -x; ./pingPongBallFocused -nl $nc --N=$pn_els --numDims=2 --randomOverlap=$pn_msg --timeToRun=$time_to_run --algorithm=$alg)
             echo ""
           done
         done
@@ -53,7 +53,7 @@ if [[ "$runStrongScaling" == 'true' ]]; then
       for nc in "${nodecount[@]}"; do
         for pn_msg in "${num_balls[@]}"; do
           for pn_els in "${sqrt_els[@]}"; do
-            (set -x ./pingPongStencil -nl $nc --N=$pn_els --numDims=2 --numBalls=$pn_msg --timeToRun=$time_to_run)
+            (set -x; ./pingPongStencil -nl $nc --N=$pn_els --numDims=2 --randomOverlap=$pn_msg --timeToRun=$time_to_run)
             echo ""
           done
         done
@@ -73,7 +73,7 @@ if [[ "$runWeakScaling" == 'true' ]]; then
           for pn_els in "${sqrt_els_per_node[@]}"; do
             n=$(echo "(sqrt($pn_els*$pn_els*$nc))/1" | bc)
             nBalls=$(echo "($pn_msg*$nc)/1" | bc)
-            (set -x ./pingPongBallFocused -nl $nc --N=$n --numDims=2 --numBalls=$nBalls --timeToRun=$time_to_run --algorithm=$alg)
+            (set -x; ./pingPongBallFocused -nl $nc --N=$n --numDims=2 --randomOverlap=$nBalls --timeToRun=$time_to_run --algorithm=$alg)
             echo ""
           done
         done
@@ -88,7 +88,7 @@ if [[ "$runWeakScaling" == 'true' ]]; then
         for pn_els in "${sqrt_els_per_node[@]}"; do
           n=$(echo "(sqrt($pn_els*$pn_els*$nc))/1" | bc)
           nBalls=$(echo "($pn_msg*$nc)/1" | bc)
-          (set -x ./pingPongBallStencil -nl $nc --N=$n --numDims=2 --numBalls=$nBalls --timeToRun=$time_to_run)
+          (set -x; ./pingPongStencil -nl $nc --N=$n --numDims=2 --randomOverlap=$nBalls --timeToRun=$time_to_run)
           echo ""
         done
       done

--- a/chplPingPong/doit
+++ b/chplPingPong/doit
@@ -1,60 +1,97 @@
 #!/usr/bin/env bash
 
-if [[ $# -eq 1 && "$1" == "clean" ]]; then
-    set -e -x
-    rm -f *.o pingpongballs pingpongballs_real ./tmp
-    exit
-fi
+# Note all experiments are conducted using the '--randomOverlap' approach for
+# ball placement.
+
+runStrongScaling=true         # set to 'true' to run strong scaling experiments
+runWeakScaling=true           # set to 'true' to run weak scaling experiments
+runBallFocusedApproach=true   # set to 'true' to run ball-focused approach
+runStencilBasedApproach=true  # set to 'true' to run stencil-focused approach
+
+nodecount=( 1 2 4 8 16 32)    # list of number of nodes to run experiments on 
+algs=( 0)  # how to conduct ball focused version. 0 = w/ outer, synchronizing,
+           # time-loop; 1 = w/ inner, non-synchronizing, time-loop
+time_to_run=1000  # how long to run each simulation (in simulated seconds)
+
+# Parameters to set for 'strong' scaling experiments; add to list to
+# conduct additional experiments:
+sqrt_els_per_node=( 128)    # sqrt of number of pongers on each node
+messages_per_node=( 512)    # number of balls to place on each node
+
+# Parameters to set for 'weak' scaling experiments; add to list to
+# conduct additional experiments:
+sqrt_els=( 1024)    # sqrt of number of pongers across all nodes
+num_balls=( 1024)   # total number of balls across all nodes
+
+# -----------------------------------------------------------------------------
+
+set -e
 
 (set -x; chpl --fast pingPongBallFocused.chpl)
-#(set -x; chpl --fast pingPongStencil.chpl)
+(set -x; chpl --fast pingPongStencil.chpl)
 
-#(set -x; ./pingPongBallFocused --N 1024 --edgeDelay 10 --timeToRun 100 --random 1024 --artificialWork 0)
-(set -x; ./pingPongBallFocused --N 1024 --edgeDelay 10 --timeToRun 100 --random 1024 --artificialWork 250000)
-#(set -x; ./pingPongBallFocused --N 1024 --edgeDelay 10 --timeToRun 100 --random 1024 --artificialWork 50000000)
-#(set -x; ./pingPongBallFocused --N 1024 --edgeDelay 10 --timeToRun 100 --random 1024 --artificialWork 75000000)
-#(set -x; ./pingPongBallFocused --N 1024 --edgeDelay 10 --timeToRun 100 --random 1024 --artificialWork 100000000)
-#(set -x; ./pingPongBallFocused --N 1024 --edgeDelay 10 --timeToRun 100 --random 1024 --artificialWork 125000000)
-#(set -x; ./pingPongBallFocused --N 1024 --edgeDelay 10 --timeToRun 100 --random 1024 --artificialWork 150000000)
-#(set -x; ./pingPongBallFocused --N 1024 --edgeDelay 10 --timeToRun 100 --random 1024 --artificialWork 175000000)
-#(set -x; ./pingPongBallFocused --N 1024 --edgeDelay 10 --timeToRun 100 --random 1024 --artificialWork 200000000)
-exit
+if [[ "$runStrongScaling" == 'true' ]]; then
+  echo '==== CONDUCTING STRONG SCALING EXPERIMENTS ===='
 
-nodecount=( 1 2 4 8 16 32)
-#algs=( 0 1 2)
-algs=( 0)
-sqrt_els_per_node=128
-messages_per_node=512
-#num_timesteps=300000000
-num_timesteps=300
-time_to_run=$(echo "($num_timesteps*50)/1" | bc)
+  if [[ "$runBallFocusedApproach" == 'true' ]]; then
+    echo '-- RUNNING "BALL FOCUSED" APPROACH --'
+    for alg in "${algs[@]}"; do
+      for nc in "${nodecount[@]}"; do
+        for pn_msg in "${num_balls[@]}"; do
+          for pn_els in "${sqrt_els[@]}"; do
+            (set -x ./pingPongBallFocused -nl $nc --N=$pn_els --numDims=2 --numBalls=$pn_msg --timeToRun=$time_to_run --algorithm=$alg)
+            echo ""
+          done
+        done
+      done
+    done
+  fi
 
-#for alg in "${algs[@]}"; do
-#  for nc in "${nodecount[@]}"; do
-#    n=$(echo "(sqrt($sqrt_els_per_node*$sqrt_els_per_node*$nc))/1" | bc)
-#    nBalls=$(echo "($messages_per_node*$nc)/1" | bc)
-#    ./pingPongBallFocused -nl $nc --N=$n --numDims=2 --numBalls=$nBalls --timeToRun=$time_to_run --algorithm=$alg
-#  done
-#
-#  echo ""
-#done
+  if [[ "$runStencilBasedApproach" == 'true' ]]; then
+    echo '-- NEXT RUNNING "STENCIL FOCUSED" APPROACH --'
+    for alg in "${algs[@]}"; do
+      for nc in "${nodecount[@]}"; do
+        for pn_msg in "${num_balls[@]}"; do
+          for pn_els in "${sqrt_els[@]}"; do
+            (set -x ./pingPongStencil -nl $nc --N=$pn_els --numDims=2 --numBalls=$pn_msg --timeToRun=$time_to_run)
+            echo ""
+          done
+        done
+      done
+    done
+  fi
+fi
 
+if [[ "$runWeakScaling" == 'true' ]]; then
+  echo '==== CONDUCTING WEAK SCALING EXPERIMENTS ===='
 
-nodecount=( 1 2 4 8 16 32)
-sqrt_els_per_node=92681
-messages_per_node=512
-num_timesteps=10
-time_to_run=$(echo "($num_timesteps*50)/1" | bc)
+  if [[ "$runBallFocusedApproach" == 'true' ]]; then
+    echo '-- RUNNING "BALL FOCUSED" APPROACH --'
+    for alg in "${algs[@]}"; do
+      for nc in "${nodecount[@]}"; do
+        for pn_msg in "${messages_per_node[@]}"; do
+          for pn_els in "${sqrt_els_per_node[@]}"; do
+            n=$(echo "(sqrt($pn_els*$pn_els*$nc))/1" | bc)
+            nBalls=$(echo "($pn_msg*$nc)/1" | bc)
+            (set -x ./pingPongBallFocused -nl $nc --N=$n --numDims=2 --numBalls=$nBalls --timeToRun=$time_to_run --algorithm=$alg)
+            echo ""
+          done
+        done
+      done
+    done
+  fi
 
-# weak scaling
-for nc in "${nodecount[@]}"; do
-  n=$(echo "(sqrt($sqrt_els_per_node*$sqrt_els_per_node*$nc))/1" | bc)
-  nBalls=$(echo "($messages_per_node*$nc)/1" | bc)
-  (set -x; ./pingPongStencil -nl $nc --N=$n --numDims=2 --numBalls=$nBalls --timeToRun=$time_to_run)
-done
-
-# strong scaling
-#for nc in "${nodecount[@]}"; do
-#  (set -x; ./pingPongStencil -nl $nc --N=1024 --numDims=2 --numBalls=128 --timeToRun=30000)
-#done
-
+  if [[ "$runStencilBasedApproach" == 'true' ]]; then
+    echo '-- NEXT RUNNING "STENCIL FOCUSED" APPROACH --'
+    for nc in "${nodecount[@]}"; do
+      for pn_msg in "${messages_per_node[@]}"; do
+        for pn_els in "${sqrt_els_per_node[@]}"; do
+          n=$(echo "(sqrt($pn_els*$pn_els*$nc))/1" | bc)
+          nBalls=$(echo "($pn_msg*$nc)/1" | bc)
+          (set -x ./pingPongBallStencil -nl $nc --N=$n --numDims=2 --numBalls=$nBalls --timeToRun=$time_to_run)
+          echo ""
+        done
+      done
+    done
+  fi
+fi

--- a/chplPingPong/pingPongBallFocused.chpl
+++ b/chplPingPong/pingPongBallFocused.chpl
@@ -142,7 +142,7 @@ if corners {
   }
 } else if randomOverlap >= 0 {
   var rs = new randomStream(int);
-  for 0..<(N * N) {
+  for 0..<numBalls {
     const r = rs.next(0, N*N -1);
     const x = r % N;
     const y = r / N;

--- a/chplPingPong/pingPongStencil.chpl
+++ b/chplPingPong/pingPongStencil.chpl
@@ -187,7 +187,7 @@ if corners {
   applyBorderBounceback(board1);
 } else if randomOverlap >= 0 {
   var rs = new randomStream(int);
-  for 0..<(N * N) {
+  for 0..<numBalls {
     const r = rs.next(0, N*N -1);
     const x = r % N;
     const y = r / N;


### PR DESCRIPTION
This PR adds a README file to the directory containing the Chapel variants of "ping pong".

It also updates the `doit` script in that directory. This script conducts a bunch of scalability experiments of the Chapel variants and includes a number of parameters at the top to dictate how to conduct these experiments.

I also fix a bug in the Chapel implementation involving how we set things up when using `--randomOverlap`.