### PR TITLE
additional fixes to ping pong

### DIFF
--- a/Ponger.cpp
+++ b/Ponger.cpp
@@ -121,7 +121,7 @@ void Ponger::handleWestPort(SST::Event *ev) {
 }
 
 void Ponger::handleEastPort(SST::Event *ev) {
-  handlePort(dynamic_cast<BallEvent*>(ev), "-----> ", "eastPort", eastPort, "westPort", westPort);
+  handlePort(dynamic_cast<BallEvent*>(ev), "<----- ", "eastPort", eastPort, "westPort", westPort);
 }
 
 #ifdef ENABLE_SSTDBG

--- a/pingpong.py
+++ b/pingpong.py
@@ -11,6 +11,7 @@ parser.add_argument('--edgeDelay',      type=int, default=50)
 parser.add_argument('--artificialWork', type=int, default=0)
 parser.add_argument('--verbose',        default=False, action='store_true')
 group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--single',          default=False, action='store_true')
 group.add_argument('--corners',         default=False, action='store_true')
 group.add_argument('--random',          type=int, default=-1)
 group.add_argument('--randomOverlap',   type=int, default=-1)
@@ -33,12 +34,12 @@ def link(x, y, direction):
 
 # -----------------------------------------------------------------------------
 
-ballGen = sst.Component("sim", "pingpong.simulator")
-ballGen.addParams({"timeToRun"      : args.timeToRun,
+simulator = sst.Component("sim", "pingpong.simulator")
+simulator.addParams({"timeToRun"      : args.timeToRun,
                    "verbose"        : args.verbose,
                    "artificialWork" : args.artificialWork})
 
-pingPongers = []
+pingPongers = {}
 ballsHeadingNorthAt = {}
 ballsHeadingSouthAt = {}
 ballsHeadingWestAt  = {}
@@ -49,16 +50,27 @@ NE_PONGER = args.N-1
 SW_PONGER = args.N * (args.N-1)
 SE_PONGER = (args.N * args.N) - 1
 
-if args.corners:
-  ballsHeadingEastAt[NW_PONGER] = 1
-  ballsHeadingWestAt[NE_PONGER] = 1
-  if args.numDims > 1:
-      ballsHeadingEastAt[SW_PONGER] = 1
-      ballsHeadingWestAt[SE_PONGER] = 1
-      ballsHeadingSouthAt[NW_PONGER] = 1
-      ballsHeadingSouthAt[NE_PONGER] = 1
-      ballsHeadingNorthAt[SW_PONGER] = 1
-      ballsHeadingNorthAt[SE_PONGER] = 1
+if args.single:
+  if args.numDims == 1:
+    ballsHeadingSouthAt[NW_PONGER] = 1
+  elif args.numDims == 2:
+    ballsHeadingEastAt[NW_PONGER] = 1
+  else:
+    print("Invalid configuration")
+    exit(1)
+elif args.corners:
+  if args.numDims == 1:
+    ballsHeadingEastAt[NW_PONGER] = 1
+    ballsHeadingWestAt[NE_PONGER] = 1
+  elif args.numDims > 1:
+    ballsHeadingEastAt[NW_PONGER] = 1
+    ballsHeadingWestAt[NE_PONGER] = 1
+    ballsHeadingEastAt[SW_PONGER] = 1
+    ballsHeadingWestAt[SE_PONGER] = 1
+    ballsHeadingSouthAt[NW_PONGER] = 1
+    ballsHeadingSouthAt[NE_PONGER] = 1
+    ballsHeadingNorthAt[SW_PONGER] = 1
+    ballsHeadingNorthAt[SE_PONGER] = 1
 elif args.random != -1:
   sample = random.sample(range(args.N * args.N), min(args.N *args.N,args.random))
   for r in sample:
@@ -71,10 +83,10 @@ elif args.randomOverlap != -1:
   for _ in range(args.randomOverlap):
     r = random.randint(0, args.N * args.N - 1)
     direction = random.randint(0,3)
-    if direction   == 0: ballsHeadingNorthAt[r] = 1
-    elif direction == 1: ballsHeadingSouthAt[r] = 1
-    elif direction == 2: ballsHeadingWestAt[r]  = 1
-    elif direction == 3: ballsHeadingEastAt[r]  = 1
+    if direction   == 0: ballsHeadingNorthAt[r] = ballsHeadingNorthAt.get(r,0) + 1
+    elif direction == 1: ballsHeadingSouthAt[r] = ballsHeadingSouthAt.get(r,0) + 1
+    elif direction == 2: ballsHeadingWestAt[r]  = ballsHeadingWestAt.get(r,0) + 1
+    elif direction == 3: ballsHeadingEastAt[r]  = ballsHeadingEastAt.get(r,0) + 1
 elif args.wavefront:
   for i in range(0,args.N):
      ballsHeadingSouthAt[i]                   = 1
@@ -95,26 +107,26 @@ if args.verbose:
       if me in ballsHeadingSouthAt: print("%5i %s" % (me, "south"))
       if me in ballsHeadingNorthAt: print("%5i %s" % (me, "north"))
 
-for i in [0] if args.numDims == 1 else range(0,args.N):
-  for j in range(0,args.N):
+for i in range(0,args.N):
+  for j in [0] if args.numDims == 1 else range(0,args.N):
     me = i * args.N + j;
-    ponger = sst.Component("pong_%i" % (me), "pingpong.ponger")
+    ponger = sst.Component("pong_%i_%i" % (i,j), "pingpong.ponger")
     ponger.addParams({
       "ballsHeadingNorth": ballsHeadingNorthAt.get(me, 0),
       "ballsHeadingSouth": ballsHeadingSouthAt.get(me, 0),
       "ballsHeadingWest":  ballsHeadingWestAt.get(me, 0),
       "ballsHeadingEast":  ballsHeadingEastAt.get(me, 0)})
-    pingPongers.append(ponger);
+    pingPongers[me] = ponger;
 
 # i = row, j = col, (0,0) = north west corner
-for i in [0] if args.numDims == 1 else range(0,args.N):
-  for j in range(0,args.N):
+for i in range(0,args.N):
+  for j in [0] if args.numDims == 1 else range(0,args.N):
     me = i * args.N + j;
     neighborS = me + args.N
     neighborE = me + 1
 
-    connectS = i < args.N-1 and args.numDims > 1
-    connectE = j < args.N-1
+    connectS = i < args.N-1 
+    connectE = j < args.N-1 and args.numDims > 1
 
     if connectS:
       link(pingPongers[me], pingPongers[neighborS], "south")

--- a/pingpong_hyper.py
+++ b/pingpong_hyper.py
@@ -125,11 +125,11 @@ if nGrids % numRanks != 0:
 
 if myRank == 0:
   print("Simulating %d, %dx%d grids" % (nGrids, N, N))
-  ballGen = sst.Component("sim", "pingpong.simulator")
-  ballGen.addParams({"timeToRun"      : args.timeToRun,
+  simulation = sst.Component("sim", "pingpong.simulator")
+  simulation.addParams({"timeToRun"      : args.timeToRun,
                      "verbose"        : args.verbose,
                      "artificialWork" : args.artificialWork})
-  ballGen.setRank(0)
+  simulation.setRank(0)
 
 # Consider if we have 400 2x2 grids, we assign inter-grid connections as
 # follows, where each * is a point in the 2x2 grid.  The number above each

--- a/pingpong_parLoad.py
+++ b/pingpong_parLoad.py
@@ -56,11 +56,11 @@ if myRank == 0:
   warnIfNotDivisibleByNumRanks(args.randomOverlap)
 
 if myRank == 0:
-  ballGen = sst.Component("sim", "pingpong.simulator")
-  ballGen.addParams({"timeToRun"      : args.timeToRun,
+  simulator = sst.Component("sim", "pingpong.simulator")
+  simulator.addParams({"timeToRun"      : args.timeToRun,
                      "verbose"        : args.verbose,
                      "artificialWork" : args.artificialWork})
-  ballGen.setRank(0)
+  simulator.setRank(0)
 
 pingPongers = {}
 ballsHeadingNorthAt = {}


### PR DESCRIPTION
- Fix bug with how we were reporting east-facing balls
- Add -single option to serial-load Python script
- Rename `ballGen` object to `simulator` (it doesn't generate balls)
- Have serial load ping pong arrange pongers in a column instead of a row (so it's consistent with our parallel load version)
- Other misc tweaks and bug fixes.